### PR TITLE
belinda's-closet_4_refactored-delete-updated unit test

### DIFF
--- a/src/products/services/products/products.service.spec.ts
+++ b/src/products/services/products/products.service.spec.ts
@@ -1,9 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ProductsService } from './products.service';
-import { Model } from 'mongoose';
+import { Model, Types } from 'mongoose';
 import { Product } from '../../schemas/product.schema';
 import { getModelToken } from '@nestjs/mongoose';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 
 describe('ProductsService', () => {
   let service: ProductsService;
@@ -17,7 +17,7 @@ describe('ProductsService', () => {
   }
 
   let mockProduct = {
-    id: '123',
+    id: new Types.ObjectId().toHexString(),
     createByUserID: '',
     productType: [],
     productGender: [],
@@ -144,22 +144,39 @@ describe('ProductsService', () => {
   });
   
   describe('delete', () => {
-    it('should call findByIdAndUpdate on the model and return a result', async () => {
-      const deletedProduct = {
-        ...mockProduct,
-        isHidden: true
-      };
+    const deletedProduct = {
+    ...mockProduct,
+    isHidden: true
+    };
+    beforeEach(() => {
       jest
-        .spyOn(model, 'findByIdAndUpdate')
-        .mockReturnValue({
-          exec: jest.fn().mockResolvedValueOnce(deletedProduct)
-        } as any);
+      .spyOn(model, 'findByIdAndUpdate')
+      .mockReturnValue({
+        exec: jest.fn().mockResolvedValueOnce(deletedProduct)
+      } as any);
+    });
+    it('should call findByIdAndUpdate on the model and return a result', async () => {
       const result = await service.delete(mockProduct.id);
       expect(model.findByIdAndUpdate).toHaveBeenCalledWith(
         mockProduct.id,
         { isHidden: true }
       );
       expect(result).toEqual(deletedProduct);
+    });
+    it('should throw BadRequestException error when an invalid id is provided', async () => {
+      await expect(service.delete('invalidId')).rejects.toThrow(BadRequestException);
+    });
+    it('should throw NotFoundException error when product not found', async () => {
+      jest
+        .spyOn(model, 'findByIdAndUpdate')
+        .mockReturnValue({
+          exec: jest.fn().mockResolvedValueOnce(null),
+        } as any);
+      await expect(service.delete(mockProduct.id)).rejects.toThrow(NotFoundException);
+      expect(model.findByIdAndUpdate).toHaveBeenCalledWith(
+        mockProduct.id,
+        { isHidden: true }
+      );
     });
   });
 });

--- a/src/products/services/products/products.service.ts
+++ b/src/products/services/products/products.service.ts
@@ -59,13 +59,12 @@ export class ProductsService {
   }
 
   async delete(id: string): Promise<Product> {
+    this.logger.log(`Soft deleting Product with id: ${id}`, this.SERVICE);
     if (!Types.ObjectId.isValid(id)) {
       this.logger.warn('Invalid Id format');
       throw new BadRequestException('Invalid Id format');
     }
-    const objectId = new Types.ObjectId(id);
-    this.logger.log(`Soft deleting Product with id: ${id}`, this.SERVICE);
-    const deletedProduct = await this.productModel.findByIdAndUpdate(objectId, { isHidden: true }).exec();
+    const deletedProduct = await this.productModel.findByIdAndUpdate(id, { isHidden: true }).exec();
     if (!deletedProduct || deletedProduct === null) {
       this.logger.warn('Product not found')
       throw new NotFoundException(`Product ${id} not found`);


### PR DESCRIPTION
Resolves #70 

This PR updates the unit test for the delete function in the product service, references #56 and #64.
There is a small refactor to the function, as it was first validating the id, which we need, but when it passed that check we were creating a new Id Object to be passed. This is unnecessary.

To test:

- In your .env file make sure to set the following variables as detailed in the [installation](https://github.com/SeattleColleges/belindas-closet-nestjs/wiki/Installation) instructions for this repo.
- You must have a valid MongoDB URI string for a database connection and set it as `MONGODB_URI=<your database connection string>` in your `.env`.
- You must set `JWT_SECRET=jwt` in your`.env`.
- You must set an expiry for your JWT Secret, I did `JWT_EXPIRES = 90d` in your `.env`.
- Using the available API calls in the ProductController, use Postman to test.
- Without an Authorization token in the header you should not be able to create(POST), update(PUT), or delete(DELETE) a product making calls to the ProductController.
- Sign-up a new user or login an existing user with 'user' as their role and copy the JWT token.
- Set this token as a Header for Authorization, as seen in the first picture below. You must have the word `Bearer` and a space before your token.
- As a user you still should not be able to create(POST), update(PUT), or delete(DELETE) a product making calls to the ProductController.
- Sign-up a new user or login an existing user with 'admin' as their role and copy the JWT token.
- Set this token as a Header for Authorization, as seen in the first picture below.
- As an admin you should be able to create(POST), update(PUT), or delete(DELETE) a product making calls to the ProductController.

To test the unit tests:
- Pull this branch and open a terminal in the project
- Run the tests for the service by using the command `npm run test products.service.spec.ts`
