### PR TITLE
belinda-nest_enhancement-82-add_find_product_by_type_endpoint

### DIFF
--- a/src/products/controllers/products/products.controller.ts
+++ b/src/products/controllers/products/products.controller.ts
@@ -46,6 +46,13 @@ export class ProductsController {
     return await this.productService.findOne(id);
   }
 
+  // Find by type
+  @Get('findByType/:productType')
+  async findByType(@Param('productType') productType: string) {
+    this.logger.log(`Finding Products with type: ${productType}`, this.CONTROLLER);
+    return await this.productService.findByType(productType);
+  }
+
   @Roles('admin')
   @UseGuards(JwtAuthGuard, RoleGuard)
   @Put('update/:id')

--- a/src/products/services/products/products.service.ts
+++ b/src/products/services/products/products.service.ts
@@ -54,6 +54,17 @@ export class ProductsService {
     return product;
   }
 
+  // Find by type
+  async findByType(productType: string): Promise<Product[]> {
+    this.logger.log(`Finding Products with type: ${productType}`, this.SERVICE);
+    const products = await this.productModel.find({ productType }).exec();
+    if (!products || products.length === 0) {
+      this.logger.warn('Products not found', this.SERVICE);
+      throw new NotFoundException(`No products of type ${productType} found`);
+    }
+    return products;
+  }
+
   async updateProduct(id: string, product: Product): Promise<Product> {
     this.logger.log(`Updating Product with id: ${id}`, this.SERVICE);
     if (!Types.ObjectId.isValid(id)) {


### PR DESCRIPTION
Resolves #82 
Related: [#139](https://github.com/SeattleColleges/belindas-closet-nextjs/issues/139)
As a developer, I want to create an API endpoint that retrieves products based on specific types. This approach allows the front end to categorize products by their types.
**Approach:**
- Add find product by type logic into the product service
- Create GET request from the product controller with `findByType/:productType`

**To test:**
- Ensure the backend is running
- Using Postman and this endpoint [http://localhost:3000/api/products/findByType/Shoes](http://localhost:3000/api/products/findByType/Shoes)
- Replace `Shoes` with other product types to get results such as Shirts, Pants, Dress, etc.

Screenshot:
![image](https://github.com/SeattleColleges/belindas-closet-nestjs/assets/72054441/9d4f1779-e295-4d5a-bfe8-0223a5e81a01)
![image](https://github.com/SeattleColleges/belindas-closet-nestjs/assets/72054441/a2082033-a038-4fce-beff-5d97600190ef)

