### PR TITLE
Add role decorator, RoleGuard, and JWTAuthGuard to update user api

### DIFF
--- a/src/user/controllers/user/user.controller.ts
+++ b/src/user/controllers/user/user.controller.ts
@@ -1,7 +1,10 @@
-import { Body, Controller, Get, Inject, Logger, Param, Patch } from '@nestjs/common';
+import { Body, Controller, Get, Inject, Logger, Param, Patch, UseGuards } from '@nestjs/common';
 import { UserService } from '../../services/user/user.service';
 import { UpdateUserDto } from '../../dto/update-user.dto';
 import { User } from '../../schemas/user.schema';
+import { JwtAuthGuard } from '../../../auth/jwt.guard';
+import { Roles } from '../../../auth/roles.decorator';
+import { RoleGuard } from '../../../auth/role.guard';
 
 @Controller('user')
 export class UserController {
@@ -28,7 +31,9 @@ export class UserController {
     this.logger.log(`Getting User with email: ${email}`, this.CONTROLLER);
     return await this.userService.getUserByEmail(email);
   }
-    
+  
+  @Roles('admin')
+  @UseGuards(JwtAuthGuard, RoleGuard)
   @Patch('update/:id')
   async updateUser(@Param('id') id: string, @Body() userDto: UpdateUserDto) {
     this.logger.log(


### PR DESCRIPTION
Resolves #93

This PR adds authorization to the update user API endpoint so that only admin users are able to edit user roles. You can test this by using the PATCH method with this URL in Postman: `http://localhost:3000/api/user/update/[:id]` (replace `[:id]` with an existing user id from your database). You must add a Bearer token to headers for authorization.

After updating the user role from admin to creator using Postman:
<img width="539" alt="Screenshot 2024-03-09 062233" src="https://github.com/SeattleColleges/belindas-closet-nestjs/assets/77591083/ae373e6d-c635-4a89-a603-6779cba0381b">

Result when attempting to update user role when signed in with an account with a user or creator role, or with no token:
<img width="498" alt="Screenshot 2024-03-09 062917" src="https://github.com/SeattleColleges/belindas-closet-nestjs/assets/77591083/ff645110-a8ec-4aed-be81-b073605f872a">


Related to [#253](https://github.com/SeattleColleges/belindas-closet-nextjs/issues/253) and [#254](https://github.com/SeattleColleges/belindas-closet-nextjs/issues/254) from belindas-closet-nextjs