### PR TITLE
belindas-closet-nestjs_5_104_add-current-password

### DIFF
--- a/src/auth/dto/change-password.dto.ts
+++ b/src/auth/dto/change-password.dto.ts
@@ -4,6 +4,11 @@ export class ChangePasswordDto {
     @IsNotEmpty()
     @IsString()
     @MinLength(8, { message: 'Password must be at least 8 characters long' })
+    currentPassword: string;
+
+    @IsNotEmpty()
+    @IsString()
+    @MinLength(8, { message: 'Password must be at least 8 characters long' })
     newPassword: string;
 
     @IsNotEmpty()

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -78,11 +78,17 @@ export class AuthService {
     changePasswordDto: ChangePasswordDto,
     @GetUser() user: User,
   ) {
-    const { newPassword, confirmPassword } = changePasswordDto;
+    const { currentPassword, newPassword, confirmPassword } = changePasswordDto;
 
     // get user email and password
     const userEmail = user.email;
     const userPassword = user.password;
+
+    // compare current password with user password
+    const isValidPassword = await bcrypt.compare(currentPassword, userPassword);
+    if (!isValidPassword) {
+      throw new HttpException('Invalid credentials', 400);
+    }
 
     // check if new password and confirm password match
     if (newPassword !== confirmPassword) {
@@ -93,8 +99,8 @@ export class AuthService {
     const hashedPassword = await bcrypt.hash(newPassword, 10);
 
     // compare new password with previous password
-    const isValidPassword = await bcrypt.compare(newPassword, userPassword);
-    if (isValidPassword) {
+    const isSamePassword = await bcrypt.compare(newPassword, userPassword);
+    if (isSamePassword) {
       throw new HttpException('New password cannot be the same as previous password', 400);
     }
 


### PR DESCRIPTION
Resolves #104 
Related [#267](https://github.com/SeattleColleges/belindas-closet-android/issues/267)

As a developer, I want to add a current password parameter to ensure the user has authorized changing their password since they are aware of the current password.

**Demo:**

**Successful**
![image](https://github.com/SeattleColleges/belindas-closet-nestjs/assets/72054441/bb344f91-20c6-4025-9d14-cab45c6fb9e0)

**Error: wrong current password**
![image](https://github.com/SeattleColleges/belindas-closet-nestjs/assets/72054441/2e0ed8f6-3f4b-42a3-9e6b-c8f27d220096)

**Error: new passwords do not match**
![image](https://github.com/SeattleColleges/belindas-closet-nestjs/assets/72054441/5eb9c78d-fc9b-431e-a579-7333f39f6336)

**Error: empty input**
![image](https://github.com/SeattleColleges/belindas-closet-nestjs/assets/72054441/b366fa85-283a-40a1-aa25-d2523603b2fb)

