### PR TITLE
Belindas-closet-nestjs-6-113-enable-auto-assign-issues

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -1,0 +1,17 @@
+name: Auto-assign Issue
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: pozil/auto-assign-issue@v1
+        with:
+          github-token: ${{ secrets.AUTO_ASSIGN_ISSUE_TOKEN }}
+          assignees: ${{ github.actor }}


### PR DESCRIPTION
Resolves #113 

Once merged, this should auto-assign developers to the issues they create for this repo.