### PR TITLE
belindas-closet-nestjs_23_feature-173-user-management-backend

### DIFF
--- a/src/user/dto/user-search-filters.dto.ts
+++ b/src/user/dto/user-search-filters.dto.ts
@@ -1,0 +1,17 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { Role as UserRole } from '../schemas/user.schema';
+
+export class UserSearchFilters {
+  @IsOptional() @IsString() firstName?: string;
+  @IsOptional() @IsString() lastName?: string;
+  @IsOptional() @IsString() email?: string;
+  @IsOptional() @IsEnum(UserRole) role?: UserRole;
+  @IsOptional() @IsString() page?: string;   // query-string comes in as text
+}
+
+export interface UserSearchData {
+  data: any[];
+  page: number;
+  total: number;
+  pages: number;
+}


### PR DESCRIPTION
## Summary & Changes 📃
- **Resolves:** #173
- **Relates:** https://github.com/SeattleColleges/belindas-closet-nextjs/pull/665
- Documentation: https://salty-witness-2f5.notion.site/Admin-User-Management-System-21ad514f21a080219df8dd8188c8f5ca

- **Summary:** (Briefly describe what this PR does)
  - Expose a secure, server-side search endpoint that the new “Edit User Role” admin page can call.
  - Admins hit /users/search?... and receive a paginated list filtered by first-/last-name, e-mail, or role.
  -  Uses Mongoose regex queries with an $and array; default page = 1, limit = 9; alpha-sort by lastName.

- **Changes:**
  - `src/user/dto/user-search-filters.dto.ts` – new DTO with class-validator decorators.
  - `UserService` – added `searchUsers()` plus helper mapping; keeps existing CRUD intact.
  -  Updated imports & enum mapping to reuse the Role enum from the schema.
  - 🔗 Front-end PR #665 relies on this endpoint.


## Checklist ✅

- [X] I have **tested** this PR **locally** and it works as expected.
- [X] This PR **resolves an issue** (`Resolves #173`).
- [X] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [ ] **Squash commits** and enable **auto-merge** if approved.

